### PR TITLE
Add storage migrations for polkadot v0.9.42 -> v1.7.0 version bump

### DIFF
--- a/.github/workflows/check-migration.yml
+++ b/.github/workflows/check-migration.yml
@@ -1,0 +1,76 @@
+name: Check Migrations
+
+on:
+  push:
+    branches: ["develop"]
+  pull_request:
+    branches: ["develop"]
+  workflow_dispatch:
+
+# Cancel a currently running workflow from the same PR, branch or tag when a new workflow is
+# triggered (ref https://stackoverflow.com/a/72408109)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  runtime-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      runtime: ${{ steps.runtime.outputs.runtime }}
+    name: Extract tasks from matrix
+    steps:
+      - uses: actions/checkout@v3
+      - id: runtime
+        run: |
+          # Filter out runtimes that don't have a URI
+          TASKS=$(jq '[.[] | select(.uri != null)]' .github/workflows/runtimes-matrix.json)
+          SKIPPED_TASKS=$(jq '[.[] | select(.uri == null)]' .github/workflows/runtimes-matrix.json)
+          echo --- Running the following tasks ---
+          echo $TASKS
+          echo --- Skipping the following tasks due to not having a uri field ---
+          echo $SKIPPED_TASKS
+          # Strip whitespace from Tasks now that we've logged it
+          TASKS=$(echo $TASKS | jq -c .)
+          echo "runtime=$TASKS" >> $GITHUB_OUTPUT
+
+  check-migrations:
+    needs: [runtime-matrix]
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runtime: ${{ fromJSON(needs.runtime-matrix.outputs.runtime) }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Download try-runtime-cli
+        run: |
+          curl -sL https://github.com/paritytech/try-runtime-cli/releases/download/v0.5.2/try-runtime-x86_64-unknown-linux-musl -o try-runtime
+          chmod +x ./try-runtime
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: "3.6.1"
+
+      - name: Add wasm32-unknown-unknown target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Build ${{ matrix.runtime.name }}
+        run: |
+          cargo build --release -p ${{ matrix.runtime.package }} --features try-runtime -q --locked
+
+      - name: Check migrations
+        # Todo: enable spec-version-check dynamically if we are releasing
+        run: |
+          PACKAGE_NAME=${{ matrix.runtime.package }}
+          RUNTIME_BLOB_NAME=$(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm
+          RUNTIME_BLOB_PATH=./target/release/wbuild/$PACKAGE_NAME/$RUNTIME_BLOB_NAME
+
+          ./try-runtime \
+            --runtime $RUNTIME_BLOB_PATH \
+            on-runtime-upgrade --checks=pre-and-post \
+            --disable-spec-version-check --disable-idempotency-checks \
+            live --uri ${{ matrix.runtime.uri }}

--- a/.github/workflows/check-migration.yml
+++ b/.github/workflows/check-migration.yml
@@ -20,7 +20,7 @@ jobs:
       runtime: ${{ steps.runtime.outputs.runtime }}
     name: Extract tasks from matrix
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: runtime
         run: |
           # Filter out runtimes that don't have a URI
@@ -43,7 +43,7 @@ jobs:
         runtime: ${{ fromJSON(needs.runtime-matrix.outputs.runtime) }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download try-runtime-cli
         run: |

--- a/.github/workflows/check-migration.yml
+++ b/.github/workflows/check-migration.yml
@@ -55,8 +55,8 @@ jobs:
         with:
           version: "3.6.1"
 
-      - name: Add wasm32-unknown-unknown target
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install rust toolchain from toolchain.toml
+        run: rustup show
 
       - name: Build ${{ matrix.runtime.name }}
         run: |

--- a/.github/workflows/runtimes-matrix.json
+++ b/.github/workflows/runtimes-matrix.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "bajun",
+    "package": "bajun-runtime",
+    "path": "runtime/bajun-runtime",
+    "uri": "wss://rpc-parachain.bajun.network:443"
+  }
+]

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -151,8 +151,10 @@ pub type Executive = frame_executive::Executive<
 // entire chain state. However, this is to be expected and can be ignored:
 // https://substrate.stackexchange.com/questions/10986/runtime-upgrade-for-parachainsystemhostconfiguration
 type Migrations = (
-	// todo check how expensive that is.
-	pallet_identity::migration::versioned::V0ToV1<Runtime, { u64::MAX }>,
+	// We have currently 356 identities on Bajun, so setting the max number to be migrated to 1_000
+	// should be more than enough, while still staying in a limit that will not overweigh our
+	// runtime migration.
+	pallet_identity::migration::versioned::V0ToV1<Runtime, { 1_000 }>,
 	// Track inactive funds of the teleporter account, currently we don't use that, but it doesn't
 	// hurt either.
 	pallet_balances::migration::MigrateToTrackInactive<Runtime, xcm_config::CheckingAccount>,

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -154,7 +154,7 @@ type Migrations = (
 	// We have currently 356 identities on Bajun, so setting the max number to be migrated to 1_000
 	// should be more than enough, while still staying in a limit that will not overweigh our
 	// runtime migration.
-	pallet_identity::migration::versioned::V0ToV1<Runtime, { 1_000 }>,
+	pallet_identity::migration::versioned::V0ToV1<Runtime, 1_000>,
 	// Track inactive funds of the teleporter account, currently we don't use that, but it doesn't
 	// hurt either.
 	pallet_balances::migration::MigrateToTrackInactive<Runtime, xcm_config::CheckingAccount>,

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -152,7 +152,7 @@ pub type Executive = frame_executive::Executive<
 // https://substrate.stackexchange.com/questions/10986/runtime-upgrade-for-parachainsystemhostconfiguration
 type Migrations = (
 	// todo check how expensive that is.
-	pallet_identity::migration::versioned::V0ToV1<Runtime, { u64::MAX }	>,
+	pallet_identity::migration::versioned::V0ToV1<Runtime, { u64::MAX }>,
 	// Track inactive funds of the teleporter account, currently we don't use that, but it doesn't
 	// hurt either.
 	pallet_balances::migration::MigrateToTrackInactive<Runtime, xcm_config::CheckingAccount>,

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -147,6 +147,9 @@ pub type Executive = frame_executive::Executive<
 	Migrations,
 >;
 
+// Note: if try-runtime pre/post checks are enabled it will error when it tries to decode the
+// entire chain state. However, this is to be expected and can be ignored:
+// https://substrate.stackexchange.com/questions/10986/runtime-upgrade-for-parachainsystemhostconfiguration
 type Migrations = (
 	// todo check how expensive that is.
 	pallet_identity::migration::versioned::V0ToV1<Runtime, { u64::MAX }	>,

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -144,8 +144,20 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	(),
+	Migrations,
 >;
+
+type Migrations = (
+	// todo check how expensive that is.
+	pallet_identity::migration::versioned::V0ToV1<Runtime, { u64::MAX }	>,
+	// Track inactive funds of the teleporter account, currently we don't use that, but it doesn't
+	// hurt either.
+	pallet_balances::migration::MigrateToTrackInactive<Runtime, xcm_config::CheckingAccount>,
+	// Simple migration ordering the set of invulnerables.
+	pallet_collator_selection::migration::v1::MigrateToV1<Runtime>,
+	// Simple migration of the queue config data.
+	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
+);
 
 //type Migrations = (pallet_ajuna_awesome_avatars::migration::v6::MigrateToV6<Runtime>,);
 

--- a/runtime/bajun/src/xcm_config.rs
+++ b/runtime/bajun/src/xcm_config.rs
@@ -29,6 +29,9 @@ parameter_types! {
 	pub const RelayNetwork: Option<NetworkId> = None;
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub UniversalLocation: InteriorLocation = Parachain(ParachainInfo::parachain_id().into()).into();
+	// Potential KSM teleporter account, we don't teleport yet, but who knows. If we also have a
+	// convenience dex at some time on Ajuna, we want to have it.
+	pub CheckingAccount: AccountId = PolkadotXcm::check_account();
 }
 
 /// Type for specifying how a `Location` can be converted into an `AccountId`. This is used

--- a/runtime/bajun/src/xcm_config.rs
+++ b/runtime/bajun/src/xcm_config.rs
@@ -29,8 +29,8 @@ parameter_types! {
 	pub const RelayNetwork: Option<NetworkId> = None;
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub UniversalLocation: InteriorLocation = Parachain(ParachainInfo::parachain_id().into()).into();
-	// Potential KSM teleporter account, we don't teleport yet, but who knows. If we also have a
-	// convenience dex at some time on Ajuna, we want to have it.
+	// Potential KSM teleporter account, we don't teleport (yet). If we also have a
+	// convenience DEX for KSM<>BAJUN at some point, we want to teleport.
 	pub CheckingAccount: AccountId = PolkadotXcm::check_account();
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel    = "1.74.1"
-components = [ "clippy", "rustfmt" ]
+components = [ "clippy", "rustfmt", "rust-src" ]
 profile    = "minimal"
 targets    = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
The number of migrated storage values is reasonable; 9.40% of the total weight is used on my machine. Hence, we should not have an issue rolling out the new runtime on bajun.

Output of try-runtime on my machine (Note: I had to disable pre-and-post checks to get the weight measurement because there is currently an expected error, see comment in code. However, I also ran it with the checks enabled, and except for the expected error everything was fine.).

```console
../bin/try-runtime \ 
            --runtime ./target/release/wbuild/bajun-runtime/bajun_runtime.compact.compressed.wasm \
            on-runtime-upgrade --disable-idempotency-checks --disable-spec-version-check \
            --checks=none live --uri wss://rpc-parachain.bajun.network:443
[2024-02-17T00:14:28Z INFO  remote-ext] replacing wss:// in uri with https://: "https://rpc-parachain.bajun.network:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)
[2024-02-17T00:14:29Z INFO  remote-ext] since no at is provided, setting it to latest finalized head, 0x3dc5c80b9613fcb911a06d4846ab51f4c04af728406bc1f6898ec3ad6d327028
[2024-02-17T00:14:29Z INFO  remote-ext] since no prefix is filtered, the data for all pallets will be downloaded
[2024-02-17T00:14:29Z INFO  remote-ext] scraping key-pairs from remote at block height 0x3dc5c80b9613fcb911a06d4846ab51f4c04af728406bc1f6898ec3ad6d327028
⠼    22.775 s   Scraping keys...[2024-02-17T00:14:52Z ERROR remote-ext] Error = Transport(Server returned an error status code: 500)
✅ Found 128578 keys (46.10s)
[00:00:27] Downloading key values 2,146.4071/s [===================================>-----------------------------------------------------------] 47677/128578 (38s)[2024-02-17T00:15:43Z WARN  frame_remote_externalities] Batch request failed (2/12 retries). Error: Networking or low-level protocol error: Server returned an error status code: 500
[00:01:08] ✅ Downloaded key values 1,875.7058/s [=============================================================================================] 128578/128578 (0s)
✅ Inserted keys into DB (0.73s)
[2024-02-17T00:16:25Z INFO  remote-ext] adding data for hashed prefix: , took 115.60s
[2024-02-17T00:16:25Z INFO  remote-ext] adding data for hashed key: 3a636f6465
[2024-02-17T00:16:28Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8
[2024-02-17T00:16:28Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac
[2024-02-17T00:16:29Z INFO  remote-ext] 👩‍👦 no child roots found to scrape
[2024-02-17T00:16:29Z INFO  remote-ext] initialized state externalities with storage root 0x333c08d8cf7cfbab27057fa549588b9eaf18e242e445b0afacacc57d0be52fc3 and state_version V1
[2024-02-17T00:16:29Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("bajun")] [Version: 124] [Code hash: 0xe4db...4743]
[2024-02-17T00:16:29Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("bajun")] [Version: 200] [Code hash: 0x22bf...9fe7]
[2024-02-17T00:16:29Z INFO  try-runtime::cli] 🚀 Speed up your workflow by using snapshots instead of live state. See `try-runtime create-snapshot --help`.
[2024-02-17T00:16:29Z INFO  try_runtime_core::commands::on_runtime_upgrade] -------------------------------------------------------------------


[2024-02-17T00:16:29Z INFO  try_runtime_core::commands::on_runtime_upgrade] 🔬 Running TryRuntime_on_runtime_upgrade with checks: None


[2024-02-17T00:16:29Z INFO  try_runtime_core::commands::on_runtime_upgrade] -------------------------------------------------------------------
[2024-02-17T00:16:33Z INFO  runtime::frame-support] 🐥 New pallet "Multisig" detected in the runtime. Initializing the on-chain storage version to match the storage version defined in the pallet: StorageVersion(1)
[2024-02-17T00:16:33Z INFO  runtime::frame-support] 🐥 New pallet "Utility" detected in the runtime. The pallet has no defined storage version, so the on-chain version is being initialized to StorageVersion(0).
[2024-02-17T00:16:33Z INFO  runtime::frame-support] 🐥 New pallet "Proxy" detected in the runtime. The pallet has no defined storage version, so the on-chain version is being initialized to StorageVersion(0).
[2024-02-17T00:16:33Z INFO  runtime::frame-support] 🐥 New pallet "MessageQueue" detected in the runtime. The pallet has no defined storage version, so the on-chain version is being initialized to StorageVersion(0).
[2024-02-17T00:16:33Z INFO  runtime::frame-support] 🐥 New pallet "Nft" detected in the runtime. Initializing the on-chain storage version to match the storage version defined in the pallet: StorageVersion(1)
[2024-02-17T00:16:33Z INFO  runtime::frame-support] 🐥 New pallet "NftTransfer" detected in the runtime. The pallet has no defined storage version, so the on-chain version is being initialized to StorageVersion(0).
[2024-02-17T00:16:33Z INFO  frame_support::migrations] 🚚 Pallet "Identity" VersionedMigration migrating storage version from 0 to 1.
[2024-02-17T00:16:33Z INFO  runtime::identity::migration::v1] running storage migration from version 0 to version 1.
[2024-02-17T00:16:33Z INFO  pallet_identity::migration::v1] all 356 identities migrated
[2024-02-17T00:16:33Z INFO  runtime::balances] Storage to version 1
[2024-02-17T00:16:33Z INFO  runtime::collator-selection] Sorted 4 Invulnerables, upgraded storage to version 1
[2024-02-17T00:16:33Z INFO  frame_support::migrations] 🚚 Pallet "XcmpQueue" VersionedMigration migrating storage version from 3 to 4.
[2024-02-17T00:16:33Z INFO  try_runtime_core::commands::on_runtime_upgrade] ℹ Skipping idempotency check
[2024-02-17T00:16:33Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 27.2 KB. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-02-17T00:16:33Z INFO  try-runtime::cli] Consumed ref_time: 0.046993837s (9.40% of max 0.5s)
[2024-02-17T00:16:33Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.
```

Note: The CI will fail because of the expected error, but I don't want to disable the check in the CI. The error will be gone after this runtime-upgrade.