### PR TITLE
remove obsolete storage migrations and add rust-cache to check-migration CI

### DIFF
--- a/.github/workflows/check-migration.yml
+++ b/.github/workflows/check-migration.yml
@@ -2,9 +2,9 @@ name: Check Migrations
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: ["develop"]
   pull_request:
-    branches: [ "develop" ]
+    branches: ["develop"]
   workflow_dispatch:
 
 # Cancel a currently running workflow from the same PR, branch or tag when a new workflow is

--- a/.github/workflows/check-migration.yml
+++ b/.github/workflows/check-migration.yml
@@ -2,9 +2,9 @@ name: Check Migrations
 
 on:
   push:
-    branches: ["develop"]
+    branches: [ "develop" ]
   pull_request:
-    branches: ["develop"]
+    branches: [ "develop" ]
   workflow_dispatch:
 
 # Cancel a currently running workflow from the same PR, branch or tag when a new workflow is
@@ -35,7 +35,7 @@ jobs:
           echo "runtime=$TASKS" >> $GITHUB_OUTPUT
 
   check-migrations:
-    needs: [runtime-matrix]
+    needs: [ runtime-matrix ]
     continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
@@ -57,6 +57,11 @@ jobs:
 
       - name: Install rust toolchain from toolchain.toml
         run: rustup show
+
+      - name: Fetch cache
+        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
+        with:
+          shared-key: "check-migrations-cache"
 
       - name: Build ${{ matrix.runtime.name }}
         run: |

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -155,22 +155,7 @@ pub type Executive = frame_executive::Executive<
 	Migrations,
 >;
 
-// Note: if try-runtime pre/post checks are enabled it will error when it tries to decode the
-// entire chain state. However, this is to be expected and can be ignored:
-// https://substrate.stackexchange.com/questions/10986/runtime-upgrade-for-parachainsystemhostconfiguration
-type Migrations = (
-	// We have currently 356 identities on Bajun, so setting the max number to be migrated to 1_000
-	// should be more than enough, while still staying in a limit that will not overweigh our
-	// runtime migration.
-	pallet_identity::migration::versioned::V0ToV1<Runtime, 1_000>,
-	// Track inactive funds of the teleporter account, currently we don't use that, but it doesn't
-	// hurt either.
-	pallet_balances::migration::MigrateToTrackInactive<Runtime, xcm_config::CheckingAccount>,
-	// Simple migration ordering the set of invulnerables.
-	pallet_collator_selection::migration::v1::MigrateToV1<Runtime>,
-	// Simple migration of the queue config data.
-	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
-);
+type Migrations = ();
 
 //type Migrations = (pallet_ajuna_awesome_avatars::migration::v6::MigrateToV6<Runtime>,);
 


### PR DESCRIPTION
Removes migrations that have been rolled out on the live Bajun Network