### PR TITLE
[runtime] use relaychain block for vesting schedule.

### DIFF
--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -28,6 +28,7 @@ mod weights;
 pub mod xcm_config;
 
 use crate::gov::EnsureRootOrMoreThanHalfCouncil;
+use cumulus_pallet_parachain_system::RelaychainDataProvider;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use smallvec::smallvec;
@@ -322,10 +323,14 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 		match call {
 			RuntimeCall::Nft(NftsCall::set_attribute { namespace, .. })
 				if namespace == &AttributeNamespace::CollectionOwner =>
-				true,
+			{
+				true
+			},
 			RuntimeCall::Nft(NftsCall::set_attribute { namespace, .. })
 				if namespace != &AttributeNamespace::CollectionOwner =>
-				false,
+			{
+				false
+			},
 			_ => true,
 		}
 	}
@@ -495,7 +500,7 @@ impl orml_vesting::Config for Runtime {
 	type VestedTransferOrigin = EnsureSigned<AccountId>;
 	type WeightInfo = ();
 	type MaxVestingSchedules = frame_support::traits::ConstU32<100>;
-	type BlockNumberProvider = System;
+	type BlockNumberProvider = RelaychainDataProvider<Runtime>;
 }
 
 parameter_types! {

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -323,14 +323,10 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 		match call {
 			RuntimeCall::Nft(NftsCall::set_attribute { namespace, .. })
 				if namespace == &AttributeNamespace::CollectionOwner =>
-			{
-				true
-			},
+				true,
 			RuntimeCall::Nft(NftsCall::set_attribute { namespace, .. })
 				if namespace != &AttributeNamespace::CollectionOwner =>
-			{
-				false
-			},
+				false,
 			_ => true,
 		}
 	}


### PR DESCRIPTION
Async backing will decrease the expected block time from 12 to 6 seconds block time, which would mess up any existing vesting schedules. For a constant vesting schedule, it is better to depend on the relaychain block number. This does not need any state migration as we don't have ongoing vesting schedule. The ajuna parachain has already implemented that change.