### PR TITLE
rename `BajunDevKeys` to testnet dev keys and align code with ajuna-parachain

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,4 +1,4 @@
-use crate::chain_spec_utils::{BajunDevKeys, BajunKeys, GenesisKeys, RelayChain, WellKnownKeys};
+use crate::chain_spec_utils::{BajunKeys, GenesisKeys, RelayChain, TestnetDevKeys, WellKnownKeys};
 use bajun_runtime::{AccountId, AuraId, EXISTENTIAL_DEPOSIT};
 use cumulus_primitives_core::ParaId;
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
@@ -53,11 +53,11 @@ pub fn bajun_chain_spec(
 			BajunKeys::invulnerables(),
 			BajunKeys::governance(),
 		),
-		GenesisKeys::BajunDev => (
-			BajunDevKeys::root(),
-			vec![BajunDevKeys::root()],
-			BajunDevKeys::invulnerables(),
-			BajunDevKeys::governance(),
+		GenesisKeys::TestnetDev => (
+			TestnetDevKeys::root(),
+			vec![TestnetDevKeys::root()],
+			TestnetDevKeys::invulnerables(),
+			TestnetDevKeys::governance(),
 		),
 		GenesisKeys::WellKnown => (
 			WellKnownKeys::root(),

--- a/node/src/chain_spec_utils.rs
+++ b/node/src/chain_spec_utils.rs
@@ -19,9 +19,9 @@ where
 pub enum GenesisKeys {
 	/// Use Bajun production keys.
 	Bajun,
-	/// Use Bajun Dev keys, intended for test networks.
-	BajunDev,
-	/// Use Keys from the keyring for a test setup
+	/// Keys intended for testnets like westend, or paseo.
+	TestnetDev,
+	/// Use keys from the keyring for a test setup.
 	WellKnown,
 }
 
@@ -55,9 +55,10 @@ impl WellKnownKeys {
 	}
 }
 
-pub struct BajunDevKeys;
+/// Ajuna and Bajun share the same set of keys here.
+pub struct TestnetDevKeys;
 
-impl BajunDevKeys {
+impl TestnetDevKeys {
 	pub fn root() -> AccountId {
 		pub_sr25519("5H6WjuXTrFTpiAmr2Pohzbuj7EvBHuDNht7PSSUCCDv9u4ec").into()
 	}

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -79,7 +79,7 @@ const KUSAMA_PARA_ID: u32 = 2119;
 const WESTEND_PARA_ID: u32 = 2138;
 const LOCAL_PARA_ID: u32 = 2119;
 
-// If we don't skipp here, each cmd expands to 5 lines. I think we have better overview like this.
+// If we don't skip here, each cmd expands to 5 lines. I think we have better overview like this.
 #[rustfmt::skip]
 fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 	Ok(match id {
@@ -89,7 +89,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 
 		// fresh production/testnet chain-specs based on the current rust code.
 		"bajun-kusama-fresh" => Box::new(bajun_chain_spec(KUSAMA_PARA_ID.into(), GenesisKeys::Bajun, RelayChain::Kusama)),
-		"bajun-westend-fresh" => Box::new(bajun_chain_spec(WESTEND_PARA_ID.into(), GenesisKeys::BajunDev, RelayChain::Westend)),
+		"bajun-westend-fresh" => Box::new(bajun_chain_spec(WESTEND_PARA_ID.into(), GenesisKeys::TestnetDev, RelayChain::Westend)),
 
 		// on the spot configs
 		"bajun-kusama-local" => Box::new(bajun_chain_spec(LOCAL_PARA_ID.into(), GenesisKeys::WellKnown, RelayChain::KusamaLocal)),

--- a/runtime/bajun/Cargo.toml
+++ b/runtime/bajun/Cargo.toml
@@ -14,12 +14,12 @@ substrate-wasm-builder = { workspace = true }
 # General
 hex-literal = { workspace = true, optional = true }
 log         = { workspace = true }
-serde       = { workspace = true, features = ["derive"], optional = true }
+serde       = { workspace = true, features = [ "derive" ], optional = true }
 smallvec    = { workspace = true }
 
 # Parity codec
 parity-scale-codec = { workspace = true }
-scale-info         = { workspace = true, features = ["derive"] }
+scale-info         = { workspace = true, features = [ "derive" ] }
 
 # Substrate
 frame-benchmarking                         = { workspace = true, optional = true }

--- a/runtime/bajun/src/xcm_config.rs
+++ b/runtime/bajun/src/xcm_config.rs
@@ -1,3 +1,19 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use super::{
 	AccountId, AllPalletsWithSystem, Balances, ParachainInfo, ParachainSystem, PolkadotXcm,
 	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, WeightToFee, XcmpQueue,


### PR DESCRIPTION
The reasoning is that we want to use the same keys for our ajuna and bajun testnets. So I aligned the names in both repositories for easier maintenance.