### PR TITLE
[AJUN-342] Revert relay chain provider for vesting

### DIFF
--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -318,14 +318,10 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 		match call {
 			RuntimeCall::Nft(NftsCall::set_attribute { namespace, .. })
 				if namespace == &AttributeNamespace::CollectionOwner =>
-			{
-				true
-			},
+				true,
 			RuntimeCall::Nft(NftsCall::set_attribute { namespace, .. })
 				if namespace != &AttributeNamespace::CollectionOwner =>
-			{
-				false
-			},
+				false,
 			_ => true,
 		}
 	}

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -557,6 +557,9 @@ impl orml_vesting::Config for Runtime {
 	type VestedTransferOrigin = EnsureSigned<AccountId>;
 	type WeightInfo = weights::orml_vesting::WeightInfo<Runtime>;
 	type MaxVestingSchedules = frame_support::traits::ConstU32<100>;
+	// We use the parachain block number instead of the relay chain provider
+	// because our active schedules would get messed up if we switched to the relay
+	// chain block number instead of the parachain one
 	type BlockNumberProvider = System;
 }
 

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -28,7 +28,6 @@ mod weights;
 pub mod xcm_config;
 
 use crate::gov::EnsureRootOrMoreThanHalfCouncil;
-use cumulus_pallet_parachain_system::RelaychainDataProvider;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use smallvec::smallvec;
@@ -319,10 +318,14 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 		match call {
 			RuntimeCall::Nft(NftsCall::set_attribute { namespace, .. })
 				if namespace == &AttributeNamespace::CollectionOwner =>
-				true,
+			{
+				true
+			},
 			RuntimeCall::Nft(NftsCall::set_attribute { namespace, .. })
 				if namespace != &AttributeNamespace::CollectionOwner =>
-				false,
+			{
+				false
+			},
 			_ => true,
 		}
 	}
@@ -558,7 +561,7 @@ impl orml_vesting::Config for Runtime {
 	type VestedTransferOrigin = EnsureSigned<AccountId>;
 	type WeightInfo = weights::orml_vesting::WeightInfo<Runtime>;
 	type MaxVestingSchedules = frame_support::traits::ConstU32<100>;
-	type BlockNumberProvider = RelaychainDataProvider<Runtime>;
+	type BlockNumberProvider = System;
 }
 
 parameter_types! {


### PR DESCRIPTION
## Description

After looking into the specifics of the `cumulus_pallet_parachain_system::RelaychainDataProvider`, it seems that it does take the block number from the relay chain, in which case all currently active vestings in Bajun would get immediatly finished if active.

Because of that this PR reverts the block number provider to be the parachain block instead.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
