### PR TITLE
[GHA] also cache rust dependencies on job failure

### DIFF
--- a/.github/workflows/check-migration.yml
+++ b/.github/workflows/check-migration.yml
@@ -62,6 +62,7 @@ jobs:
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
         with:
           shared-key: "check-migrations-cache"
+          cache-on-failure: true
 
       - name: Build ${{ matrix.runtime.name }}
         run: |

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           # consistent cache across jobs
           shared-key: "bajun-cache-cargo-debug"
+          cache-on-failure: true
 
       - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
         env:
@@ -92,6 +93,7 @@ jobs:
         with:
           # consistent cache across jobs
           shared-key: "bajun-cache-cargo-release"
+          cache-on-failure: true
 
       - run: cargo test --release --all-features --all-targets
         env:
@@ -136,6 +138,7 @@ jobs:
         with:
           # consistent cache across jobs
           shared-key: "bajun-cache-zombienet"
+          cache-on-failure: true
 
       - name: Build and copy collator binary to zombienet binaries
         run: |


### PR DESCRIPTION
Most importantly this is relevant for the check-migration and the zombienet job, as they might fail after the rust binary has successfully been built.