### PR TITLE
downgrade-ajuna-pallets to v0.1.0 but with polkadot-v1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,11 +755,9 @@ dependencies = [
  "log",
  "orml-pallets-benchmarking",
  "orml-vesting",
- "pallet-ajuna-affiliates",
  "pallet-ajuna-awesome-avatars",
  "pallet-ajuna-awesome-avatars-benchmarking",
  "pallet-ajuna-nft-transfer",
- "pallet-ajuna-tournament",
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
@@ -6047,8 +6045,8 @@ dependencies = [
 
 [[package]]
 name = "orml-pallets-benchmarking"
-version = "0.7.0"
-source = "git+https://github.com/ajuna-network/ajuna-pallets.git?tag=v0.7.0#93863957a91ef3ec199cb09757890a5f3f3d201b"
+version = "0.1.0"
+source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#a26395602dd7f7bbde711772994c7ef083e3e59c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6079,31 +6077,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-ajuna-affiliates"
-version = "0.7.0"
-source = "git+https://github.com/ajuna-network/ajuna-pallets.git?tag=v0.7.0#93863957a91ef3ec199cb09757890a5f3f3d201b"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-ajuna-awesome-avatars"
-version = "0.7.0"
-source = "git+https://github.com/ajuna-network/ajuna-pallets.git?tag=v0.7.0#93863957a91ef3ec199cb09757890a5f3f3d201b"
+version = "0.1.0"
+source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#a26395602dd7f7bbde711772994c7ef083e3e59c"
 dependencies = [
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "hex",
  "log",
- "pallet-ajuna-affiliates",
  "pallet-ajuna-nft-transfer",
- "pallet-ajuna-tournament",
  "parity-scale-codec",
  "scale-info",
  "sp-io",
@@ -6113,18 +6095,16 @@ dependencies = [
 
 [[package]]
 name = "pallet-ajuna-awesome-avatars-benchmarking"
-version = "0.7.0"
-source = "git+https://github.com/ajuna-network/ajuna-pallets.git?tag=v0.7.0#93863957a91ef3ec199cb09757890a5f3f3d201b"
+version = "0.1.0"
+source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#a26395602dd7f7bbde711772994c7ef083e3e59c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "hex",
  "log",
- "pallet-ajuna-affiliates",
  "pallet-ajuna-awesome-avatars",
  "pallet-ajuna-nft-transfer",
- "pallet-ajuna-tournament",
  "pallet-balances",
  "pallet-insecure-randomness-collective-flip",
  "pallet-nfts",
@@ -6137,28 +6117,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-ajuna-nft-transfer"
-version = "0.7.0"
-source = "git+https://github.com/ajuna-network/ajuna-pallets.git?tag=v0.7.0#93863957a91ef3ec199cb09757890a5f3f3d201b"
+version = "0.1.0"
+source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#a26395602dd7f7bbde711772994c7ef083e3e59c"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-ajuna-tournament"
-version = "0.7.0"
-source = "git+https://github.com/ajuna-network/ajuna-pallets.git?tag=v0.7.0#93863957a91ef3ec199cb09757890a5f3f3d201b"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic",
  "sp-runtime",
  "sp-std",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6046,7 +6046,7 @@ dependencies = [
 [[package]]
 name = "orml-pallets-benchmarking"
 version = "0.1.0"
-source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#a26395602dd7f7bbde711772994c7ef083e3e59c"
+source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#24b4c3d666af902e8d024e615647ab3f552f0f14"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6079,7 +6079,7 @@ dependencies = [
 [[package]]
 name = "pallet-ajuna-awesome-avatars"
 version = "0.1.0"
-source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#a26395602dd7f7bbde711772994c7ef083e3e59c"
+source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#24b4c3d666af902e8d024e615647ab3f552f0f14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "pallet-ajuna-awesome-avatars-benchmarking"
 version = "0.1.0"
-source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#a26395602dd7f7bbde711772994c7ef083e3e59c"
+source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#24b4c3d666af902e8d024e615647ab3f552f0f14"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "pallet-ajuna-nft-transfer"
 version = "0.1.0"
-source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#a26395602dd7f7bbde711772994c7ef083e3e59c"
+source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#24b4c3d666af902e8d024e615647ab3f552f0f14"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,14 +156,14 @@ orml-vesting = { version = "0.10.0", default-features = false }
 bajun-runtime = { path = "runtime/bajun" }
 
 # Ajuna Pallets
-pallet-ajuna-affiliates                   = { git = "https://github.com/ajuna-network/ajuna-pallets.git", tag = "v0.7.0", default-features = false }
-pallet-ajuna-awesome-avatars              = { git = "https://github.com/ajuna-network/ajuna-pallets.git", tag = "v0.7.0", default-features = false }
-pallet-ajuna-battle-mogs                  = { git = "https://github.com/ajuna-network/ajuna-pallets.git", tag = "v0.7.0", default-features = false }
-pallet-ajuna-awesome-avatars-benchmarking = { git = "https://github.com/ajuna-network/ajuna-pallets.git", tag = "v0.7.0", default-features = false }
-pallet-ajuna-nft-transfer                 = { git = "https://github.com/ajuna-network/ajuna-pallets.git", tag = "v0.7.0", default-features = false }
-pallet-ajuna-nft-staking                  = { git = "https://github.com/ajuna-network/ajuna-pallets.git", tag = "v0.7.0", default-features = false }
-pallet-ajuna-tournament                   = { git = "https://github.com/ajuna-network/ajuna-pallets.git", tag = "v0.7.0", default-features = false }
-orml-pallets-benchmarking                 = { git = "https://github.com/ajuna-network/ajuna-pallets.git", tag = "v0.7.0", default-features = false }
+#pallet-ajuna-affiliates                   = { git = "https://github.com/ajuna-network/ajuna-pallets.git", tag = "v0.7.0", default-features = false }
+pallet-ajuna-awesome-avatars              = { git = "https://github.com/ajuna-network/ajuna-pallets.git", branch = "v0.1.0-polkadot-v1.10.0", default-features = false }
+pallet-ajuna-battle-mogs                  = { git = "https://github.com/ajuna-network/ajuna-pallets.git", branch = "v0.1.0-polkadot-v1.10.0", default-features = false }
+pallet-ajuna-awesome-avatars-benchmarking = { git = "https://github.com/ajuna-network/ajuna-pallets.git", branch = "v0.1.0-polkadot-v1.10.0", default-features = false }
+pallet-ajuna-nft-transfer                 = { git = "https://github.com/ajuna-network/ajuna-pallets.git", branch = "v0.1.0-polkadot-v1.10.0", default-features = false }
+pallet-ajuna-nft-staking                  = { git = "https://github.com/ajuna-network/ajuna-pallets.git", branch = "v0.1.0-polkadot-v1.10.0", default-features = false }
+#pallet-ajuna-tournament                   = { git = "https://github.com/ajuna-network/ajuna-pallets.git", tag = "v0.7.0", default-features = false }
+orml-pallets-benchmarking                 = { git = "https://github.com/ajuna-network/ajuna-pallets.git", branch = "v0.1.0-polkadot-v1.10.0", default-features = false }
 
 [profile.production]
 codegen-units = 1

--- a/runtime/bajun/Cargo.toml
+++ b/runtime/bajun/Cargo.toml
@@ -91,11 +91,11 @@ staging-parachain-info              = { workspace = true }
 orml-vesting = { workspace = true }
 
 # Ajuna Pallets
-pallet-ajuna-affiliates                   = { workspace = true }
+#pallet-ajuna-affiliates                   = { workspace = true }
 pallet-ajuna-awesome-avatars              = { workspace = true }
 pallet-ajuna-awesome-avatars-benchmarking = { workspace = true, optional = true }
 pallet-ajuna-nft-transfer                 = { workspace = true }
-pallet-ajuna-tournament                   = { workspace = true }
+#pallet-ajuna-tournament                   = { workspace = true }
 orml-pallets-benchmarking                 = { workspace = true, optional = true }
 
 [features]
@@ -168,11 +168,9 @@ std = [
     "staging-xcm-builder/std",
     "staging-xcm-executor/std",
     # ajuna
-    "pallet-ajuna-affiliates/std",
     "pallet-ajuna-awesome-avatars/std",
     "pallet-ajuna-awesome-avatars-benchmarking?/std",
     "pallet-ajuna-nft-transfer/std",
-    "pallet-ajuna-tournament/std",
 ]
 
 runtime-benchmarks = [
@@ -213,11 +211,11 @@ runtime-benchmarks = [
     "staging-xcm-builder/runtime-benchmarks",
     "staging-xcm-executor/runtime-benchmarks",
     # ajuna
-    "pallet-ajuna-affiliates/runtime-benchmarks",
+#    "pallet-ajuna-affiliates/runtime-benchmarks",
     "pallet-ajuna-awesome-avatars/runtime-benchmarks",
     "pallet-ajuna-awesome-avatars-benchmarking/runtime-benchmarks",
     "pallet-ajuna-nft-transfer/runtime-benchmarks",
-    "pallet-ajuna-tournament/runtime-benchmarks",
+#    "pallet-ajuna-tournament/runtime-benchmarks",
 ]
 
 try-runtime = [
@@ -257,9 +255,9 @@ try-runtime = [
     "sp-runtime/try-runtime",
     "staging-parachain-info/try-runtime",
     # ajuna
-    "pallet-ajuna-affiliates/try-runtime",
+#    "pallet-ajuna-affiliates/try-runtime",
     "pallet-ajuna-awesome-avatars/try-runtime",
     "pallet-ajuna-awesome-avatars-benchmarking/try-runtime",
-    "pallet-ajuna-tournament/try-runtime",
+#    "pallet-ajuna-tournament/try-runtime",
     "pallet-ajuna-nft-transfer/try-runtime",
 ]

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -64,7 +64,6 @@ use frame_support::{
 };
 use frame_system::{
 	limits::{BlockLength, BlockWeights},
-	pallet_prelude::BlockNumberFor,
 	EnsureRoot, EnsureSigned, EnsureWithSuccess,
 };
 use pallet_identity::legacy::IdentityInfo;
@@ -374,35 +373,36 @@ impl frame_system::Config for Runtime {
 	/// The Block provider type
 	type Block = Block;
 	type RuntimeTask = RuntimeTask;
-	type SingleBlockMigrations = SingleBlockMigrations;
+	type SingleBlockMigrations = ();
 	type MultiBlockMigrator = pallet_migrations::Pallet<Runtime>;
 	type PreInherents = ();
 	type PostInherents = ();
 	type PostTransactions = ();
 }
 
-type SingleBlockMigrations = (pallet_ajuna_awesome_avatars::migration::v6::MigrateToV6<Runtime>,);
+// type SingleBlockMigrations =
+// (pallet_ajuna_awesome_avatars::migration::v6::MigrateToV6<Runtime>,);
 
-#[cfg(not(feature = "runtime-benchmarks"))]
-use mbm::MultiBlockMigrations;
-
-#[cfg(not(feature = "runtime-benchmarks"))]
-mod mbm {
-	use crate::Runtime;
-	use pallet_ajuna_awesome_avatars::migration::v6::mbm::{
-		LazyMigrationAvatarV5ToV6, LazyMigrationPlayerSeasonConfigsV5ToV6,
-		LazyMigrationSeasonStatsV5ToV6, LazyTradeStatsMapCleanup,
-	};
-
-	use crate::weights::pallet_ajuna_awesome_avatars_mbm::WeightInfo as AaaMbmWeight;
-
-	pub type MultiBlockMigrations = (
-		LazyMigrationPlayerSeasonConfigsV5ToV6<Runtime, AaaMbmWeight<Runtime>>,
-		LazyMigrationSeasonStatsV5ToV6<Runtime, AaaMbmWeight<Runtime>>,
-		LazyMigrationAvatarV5ToV6<Runtime, AaaMbmWeight<Runtime>>,
-		LazyTradeStatsMapCleanup<Runtime, AaaMbmWeight<Runtime>>,
-	);
-}
+// #[cfg(not(feature = "runtime-benchmarks"))]
+// use mbm::MultiBlockMigrations;
+//
+// #[cfg(not(feature = "runtime-benchmarks"))]
+// mod mbm {
+// 	use crate::Runtime;
+// 	use pallet_ajuna_awesome_avatars::migration::v6::mbm::{
+// 		LazyMigrationAvatarV5ToV6, LazyMigrationPlayerSeasonConfigsV5ToV6,
+// 		LazyMigrationSeasonStatsV5ToV6, LazyTradeStatsMapCleanup,
+// 	};
+//
+// 	use crate::weights::pallet_ajuna_awesome_avatars_mbm::WeightInfo as AaaMbmWeight;
+//
+// 	pub type MultiBlockMigrations = (
+// 		LazyMigrationPlayerSeasonConfigsV5ToV6<Runtime, AaaMbmWeight<Runtime>>,
+// 		LazyMigrationSeasonStatsV5ToV6<Runtime, AaaMbmWeight<Runtime>>,
+// 		LazyMigrationAvatarV5ToV6<Runtime, AaaMbmWeight<Runtime>>,
+// 		LazyTradeStatsMapCleanup<Runtime, AaaMbmWeight<Runtime>>,
+// 	);
+// }
 
 parameter_types! {
 	pub MbmServiceWeight: Weight = Perbill::from_percent(80) * RuntimeBlockWeights::get().max_block;
@@ -419,7 +419,7 @@ impl pallet_migrations::Config for Runtime {
 	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = pallet_migrations::mock_helpers::MockedMigrations;
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	type Migrations = MultiBlockMigrations;
+	type Migrations = ();
 }
 
 /// Records all started and completed upgrades in `UpgradesStarted` and `UpgradesCompleted`.
@@ -831,9 +831,9 @@ impl pallet_ajuna_awesome_avatars::Config for Runtime {
 	type KeyLimit = KeyLimit;
 	type ValueLimit = ValueLimit;
 	type NftHandler = NftTransfer;
-	type FeeChainMaxLength = AffiliateMaxLevel;
-	type AffiliateHandler = AffiliatesAAA;
-	type TournamentHandler = TournamentAAA;
+	// type FeeChainMaxLength = AffiliateMaxLevel;
+	// type AffiliateHandler = AffiliatesAAA;
+	// type TournamentHandler = TournamentAAA;
 	type WeightInfo = pallet_ajuna_awesome_avatars::weights::AjunaWeight<Runtime>;
 }
 
@@ -910,33 +910,33 @@ impl pallet_ajuna_nft_transfer::Config for Runtime {
 	type NftHelper = Nft;
 }
 
-parameter_types! {
-	pub const AffiliateMaxLevel: u32 = 2;
-}
-
-pub type AffiliatesInstanceAAA = pallet_ajuna_affiliates::Instance1;
-impl pallet_ajuna_affiliates::Config<AffiliatesInstanceAAA> for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RuleIdentifier = pallet_ajuna_awesome_avatars::types::AffiliateMethods;
-	type RuntimeRule = pallet_ajuna_awesome_avatars::FeePropagationOf<Runtime>;
-	type AffiliateMaxLevel = AffiliateMaxLevel;
-}
-
-parameter_types! {
-	pub const TournamentPalletId1: PalletId = PalletId(*b"aj/trmt1");
-	pub const MinimumTournamentPhaseDuration: BlockNumber = 100;
-}
-
-type TournamentInstance1 = pallet_ajuna_tournament::Instance1;
-impl pallet_ajuna_tournament::Config<TournamentInstance1> for Runtime {
-	type PalletId = TournamentPalletId1;
-	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
-	type SeasonId = pallet_ajuna_awesome_avatars::types::SeasonId;
-	type EntityId = pallet_ajuna_awesome_avatars::AvatarIdOf<Runtime>;
-	type RankedEntity = pallet_ajuna_awesome_avatars::types::Avatar<BlockNumberFor<Runtime>>;
-	type MinimumTournamentPhaseDuration = MinimumTournamentPhaseDuration;
-}
+// parameter_types! {
+// 	pub const AffiliateMaxLevel: u32 = 2;
+// }
+//
+// pub type AffiliatesInstanceAAA = pallet_ajuna_affiliates::Instance1;
+// impl pallet_ajuna_affiliates::Config<AffiliatesInstanceAAA> for Runtime {
+// 	type RuntimeEvent = RuntimeEvent;
+// 	type RuleIdentifier = pallet_ajuna_awesome_avatars::types::AffiliateMethods;
+// 	type RuntimeRule = pallet_ajuna_awesome_avatars::FeePropagationOf<Runtime>;
+// 	type AffiliateMaxLevel = AffiliateMaxLevel;
+// }
+//
+// parameter_types! {
+// 	pub const TournamentPalletId1: PalletId = PalletId(*b"aj/trmt1");
+// 	pub const MinimumTournamentPhaseDuration: BlockNumber = 100;
+// }
+//
+// type TournamentInstance1 = pallet_ajuna_tournament::Instance1;
+// impl pallet_ajuna_tournament::Config<TournamentInstance1> for Runtime {
+// 	type PalletId = TournamentPalletId1;
+// 	type RuntimeEvent = RuntimeEvent;
+// 	type Currency = Balances;
+// 	type SeasonId = pallet_ajuna_awesome_avatars::types::SeasonId;
+// 	type EntityId = pallet_ajuna_awesome_avatars::AvatarIdOf<Runtime>;
+// 	type RankedEntity = pallet_ajuna_awesome_avatars::types::Avatar<BlockNumberFor<Runtime>>;
+// 	type MinimumTournamentPhaseDuration = MinimumTournamentPhaseDuration;
+// }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
@@ -996,10 +996,10 @@ construct_runtime!(
 		NftTransfer: pallet_ajuna_nft_transfer = 61,
 
 		// Indexes 70-79 should be reserved for Affiliate instances
-		AffiliatesAAA: pallet_ajuna_affiliates::<Instance1> = 70,
+		// AffiliatesAAA: pallet_ajuna_affiliates::<Instance1> = 70,
 
 		// Indexes 80-89 should be reserved for Tournament instances
-		TournamentAAA: pallet_ajuna_tournament::<Instance1> = 80,
+		// TournamentAAA: pallet_ajuna_tournament::<Instance1> = 80,
 	}
 );
 
@@ -1033,10 +1033,10 @@ mod benches {
 		[pallet_timestamp, Timestamp]
 		// [pallet_treasury, Treasury] // treasury config is broken, needs fixes
 		[pallet_utility, Utility]
-		[pallet_ajuna_awesome_avatars, AwesomeAvatarsBench::<Runtime>]
+		// [pallet_ajuna_awesome_avatars, AwesomeAvatarsBench::<Runtime>]
 		 // Note: We have to update the path to the `WeightInfo` definition after
 		 // running the benchmarks: `pallet_ajuna_awesome_avatars::migration::v6::WeightInfo`
-		[pallet_ajuna_awesome_avatars_mbm, AwesomeAvatars]
+		// [pallet_ajuna_awesome_avatars_mbm, AwesomeAvatars]
 		[pallet_nfts, Nft]
 	);
 	// Use this section if you want to benchmark individual pallets
@@ -1220,7 +1220,7 @@ impl_runtime_apis! {
 			use frame_support::traits::StorageInfoTrait;
 			use frame_system_benchmarking::Pallet as SystemBench;
 			use cumulus_pallet_session_benchmarking::Pallet as SessionBench;
-			use pallet_ajuna_awesome_avatars_benchmarking::Pallet as AwesomeAvatarsBench;
+			// use pallet_ajuna_awesome_avatars_benchmarking::Pallet as AwesomeAvatarsBench;
 			use orml_pallets_benchmarking::vesting::Pallet as OrmlVestingBench;
 
 			let mut list = Vec::<BenchmarkList>::new();
@@ -1251,8 +1251,8 @@ impl_runtime_apis! {
 			use cumulus_pallet_session_benchmarking::Pallet as SessionBench;
 			impl cumulus_pallet_session_benchmarking::Config for Runtime {}
 
-			use pallet_ajuna_awesome_avatars_benchmarking::Pallet as AwesomeAvatarsBench;
-			impl pallet_ajuna_awesome_avatars_benchmarking::Config for Runtime {}
+			// use pallet_ajuna_awesome_avatars_benchmarking::Pallet as AwesomeAvatarsBench;
+			// impl pallet_ajuna_awesome_avatars_benchmarking::Config for Runtime {}
 
 			use orml_pallets_benchmarking::vesting::Pallet as OrmlVestingBench;
 			impl orml_pallets_benchmarking::vesting::Config for Runtime {}

--- a/runtime/bajun/src/weights/mod.rs
+++ b/runtime/bajun/src/weights/mod.rs
@@ -26,7 +26,7 @@ pub mod cumulus_pallet_parachain_system;
 pub mod cumulus_pallet_xcmp_queue;
 pub mod frame_system;
 pub mod orml_vesting;
-pub mod pallet_ajuna_awesome_avatars_mbm;
+// pub mod pallet_ajuna_awesome_avatars_mbm;
 pub mod pallet_balances;
 pub mod pallet_collator_selection;
 pub mod pallet_collective;


### PR DESCRIPTION
The reason is that we still need time to thoroughly test the multiblock migration and run system tests with the new data model we have for AAA.

However, we also want to push forward with the Bajun<>Basilisk integration, hence we'd like to release a runtime upgrade soon. So we want to downgrade the ajuna-pallets business logic to the currently deployed version on Bajun-Kusama such that we can run runtime upgrades.