### PR TITLE
Fix rococo-local relay chain execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8715,6 +8715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f276b38deaab6bff3ddfe061331901196ff992f76398bd0abc78382f4f115cf0"
 dependencies = [
  "async-trait",
+ "bitvec",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-support",
@@ -8770,6 +8771,7 @@ dependencies = [
  "polkadot-runtime-parachains",
  "polkadot-statement-distribution",
  "rococo-runtime",
+ "rococo-runtime-constants",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-block-builder",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -67,6 +67,7 @@ substrate-prometheus-endpoint  = { workspace = true }
 substrate-state-trie-migration-rpc = { workspace = true }
 
 # Polkadot
+# `rococo-native` is an ajuna adjustement, so we can run local setups.
 polkadot-cli        = { workspace = true, features = ["rococo-native"] }
 polkadot-primitives = { workspace = true, features = ["std"] }
 staging-xcm         = { workspace = true, features = ["std"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -67,7 +67,7 @@ substrate-prometheus-endpoint  = { workspace = true }
 substrate-state-trie-migration-rpc = { workspace = true }
 
 # Polkadot
-polkadot-cli        = { workspace = true }
+polkadot-cli        = { workspace = true, features = ["rococo-native"] }
 polkadot-primitives = { workspace = true, features = ["std"] }
 staging-xcm         = { workspace = true, features = ["std"] }
 


### PR DESCRIPTION
Without zombienet we could not run the collators relay-chain node, which exited with the following error:

```console
Error: Input("Relay chain argument error: Invalid input: `rococo-local` only supported with `rococo-native` feature enabled.")
```