### PR TITLE
Run single block migrations in executive to make it compatible with the try-runtime-cli

### DIFF
--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -157,6 +157,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	SingleBlockMigrations,
 >;
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
@@ -374,8 +375,13 @@ impl frame_system::Config for Runtime {
 	/// The Block provider type
 	type Block = Block;
 	type RuntimeTask = RuntimeTask;
-	type SingleBlockMigrations = SingleBlockMigrations;
-	type MultiBlockMigrator = pallet_migrations::Pallet<Runtime>;
+	// Note: Single block migrations are currently run in the classical way in the `Executive`
+	// because try-runtime doesn't support the pallet-migrations yet.
+	//
+	// Once it is supported, we want to switch to the pallet-migrations, but we **must** ensure
+	// that we remove the migrations from the `Executive` to prevent running the migrations twice.
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
 	type PreInherents = ();
 	type PostInherents = ();
 	type PostTransactions = ();

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -381,7 +381,7 @@ impl frame_system::Config for Runtime {
 	// Once it is supported, we want to switch to the pallet-migrations, but we **must** ensure
 	// that we remove the migrations from the `Executive` to prevent running the migrations twice.
 	type SingleBlockMigrations = ();
-	type MultiBlockMigrator = ();
+	type MultiBlockMigrator = pallet_migrations::Pallet<Runtime>;
 	type PreInherents = ();
 	type PostInherents = ();
 	type PostTransactions = ();


### PR DESCRIPTION
This should make our storage migration CI green again if we have applied the needed storage migrations.