### PR TITLE
Add relay chain suffix to chain name

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -70,10 +70,10 @@ pub fn bajun_chain_spec(
 	#[allow(deprecated)]
 	ChainSpec::builder(
 		bajun_runtime::WASM_BINARY.expect("WASM binary was not built, please build it!"),
-		Extensions { relay_chain: relay_chain.to_string(), para_id: para_id.into() },
+		Extensions { relay_chain: relay_chain.id().to_string(), para_id: para_id.into() },
 	)
-	.with_name("Bajun")
-	.with_id(&format!("bajun-{}", relay_chain))
+	.with_name(&format!("Bajun {}", relay_chain.name()))
+	.with_id(&format!("bajun-{}", relay_chain.id()))
 	.with_protocol_id(relay_chain.protocol_id())
 	.with_chain_type(relay_chain.chain_type())
 	.with_properties(properties)

--- a/node/src/chain_spec_utils.rs
+++ b/node/src/chain_spec_utils.rs
@@ -2,7 +2,7 @@ use bajun_runtime::{AccountId, AuraId};
 use sc_chain_spec::ChainType;
 use sp_core::{crypto::Ss58Codec, sr25519, Public};
 use sp_keyring::AccountKeyring::{Alice, Bob, Charlie, Dave, Eve, Ferdie};
-use std::{fmt::Display, str::FromStr};
+use std::str::FromStr;
 
 pub fn pub_sr25519(ss58: &str) -> sr25519::Public {
 	public_from_ss58::<sr25519::Public>(ss58)
@@ -114,9 +114,9 @@ pub enum RelayChain {
 	WestendLocal,
 }
 
-impl Display for RelayChain {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		let str = match self {
+impl RelayChain {
+	pub fn id(&self) -> &'static str {
+		match self {
 			RelayChain::Kusama => "kusama",
 			RelayChain::Paseo => "paseo",
 			RelayChain::Westend => "westend",
@@ -124,12 +124,21 @@ impl Display for RelayChain {
 			RelayChain::PaseoLocal => "paseo-local",
 			RelayChain::RococoLocal => "rococo-local",
 			RelayChain::WestendLocal => "westend-local",
-		};
-		write!(f, "{}", str)
+		}
 	}
-}
 
-impl RelayChain {
+	pub fn name(&self) -> &'static str {
+		match self {
+			RelayChain::Kusama => "Kusama",
+			RelayChain::Paseo => "Paseo",
+			RelayChain::Westend => "Westend",
+			RelayChain::KusamaLocal => "Kusama-local",
+			RelayChain::PaseoLocal => "Paseo-local",
+			RelayChain::RococoLocal => "Rococo-local",
+			RelayChain::WestendLocal => "Westend-local",
+		}
+	}
+
 	pub(crate) fn chain_type(&self) -> ChainType {
 		match self {
 			RelayChain::Kusama => ChainType::Live,

--- a/resources/bajun/paseo/bajun-paseo-raw-unsorted.json
+++ b/resources/bajun/paseo/bajun-paseo-raw-unsorted.json
@@ -1,5 +1,5 @@
 {
-  "name": "Bajun",
+  "name": "Bajun Paseo",
   "id": "bajun-paseo",
   "chainType": "Live",
   "bootNodes": [

--- a/resources/bajun/paseo/bajun-paseo-raw.json
+++ b/resources/bajun/paseo/bajun-paseo-raw.json
@@ -87,7 +87,7 @@
     }
   },
   "id": "bajun-paseo",
-  "name": "Bajun",
+  "name": "Bajun Paseo",
   "para_id": 2119,
   "properties": {
     "ss58Format": 1337,

--- a/resources/bajun/paseo/bajun-paseo.json
+++ b/resources/bajun/paseo/bajun-paseo.json
@@ -1,5 +1,5 @@
 {
-  "name": "Bajun",
+  "name": "Bajun Paseo",
   "id": "bajun-paseo",
   "chainType": "Live",
   "bootNodes": [

--- a/resources/bajun/westend/bajun-westend-raw.json
+++ b/resources/bajun/westend/bajun-westend-raw.json
@@ -84,7 +84,7 @@
     }
   },
   "id": "bajun-westend",
-  "name": "Bajun",
+  "name": "Bajun Westend",
   "para_id": 2138,
   "properties": {
     "ss58Format": 1337,

--- a/resources/bajun/westend/bajun-westend.json
+++ b/resources/bajun/westend/bajun-westend.json
@@ -1,5 +1,5 @@
 {
-  "name": "Bajun",
+  "name": "Bajun Westend",
   "id": "bajun-westend",
   "chainType": "Live",
   "bootNodes": [


### PR DESCRIPTION
For paseo and westend we don't see the relay chain in the chain name, which might be confusing, see image below. This PR fixes the hardcoded chain-specs and it also ensures that the relay chain suffix is added for newly generated chain specs.


![image](https://github.com/ajuna-network/bajun-parachain/assets/37865735/6713a3d9-8f26-4bde-bb2f-7a429aee9a86)
