### PR TITLE
[runtime] fix: replace currency variable name BAJUN -> BAJU

### DIFF
--- a/runtime/bajun/src/assets.rs
+++ b/runtime/bajun/src/assets.rs
@@ -15,8 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	weights, AccountId, Assets, Balance, Balances, Runtime, RuntimeEvent, RuntimeOrigin, BAJUN,
-	MILLI_BAJUN,
+	weights, AccountId, Assets, Balance, Balances, Runtime, RuntimeEvent, RuntimeOrigin, BAJU,
+	MILLI_BAJU,
 };
 use frame_support::{
 	pallet_prelude::ConstU32,
@@ -55,11 +55,11 @@ impl pallet_assets::Config<MainAssetsInstance> for Runtime {
 	type Currency = Balances;
 	type CreateOrigin = NoAssetCreators; //assets can only be created by root
 	type ForceOrigin = EnsureRoot<AccountId>;
-	type AssetDeposit = ConstU128<{ BAJUN }>;
-	type AssetAccountDeposit = ConstU128<{ BAJUN }>;
-	type MetadataDepositBase = ConstU128<{ BAJUN }>;
-	type MetadataDepositPerByte = ConstU128<{ 10 * MILLI_BAJUN }>;
-	type ApprovalDeposit = ConstU128<{ 10 * MILLI_BAJUN }>;
+	type AssetDeposit = ConstU128<{ BAJU }>;
+	type AssetAccountDeposit = ConstU128<{ BAJU }>;
+	type MetadataDepositBase = ConstU128<{ BAJU }>;
+	type MetadataDepositPerByte = ConstU128<{ 10 * MILLI_BAJU }>;
+	type ApprovalDeposit = ConstU128<{ 10 * MILLI_BAJU }>;
 	type StringLimit = ConstU32<50>;
 	type Freezer = ();
 	type Extra = ();

--- a/runtime/bajun/src/gov.rs
+++ b/runtime/bajun/src/gov.rs
@@ -16,7 +16,7 @@
 
 use crate::{
 	weights, AccountId, Balance, BlockNumber, Council, OriginCaller, Runtime, RuntimeBlockWeights,
-	RuntimeCall, RuntimeEvent, RuntimeOrigin, TechnicalCommittee, BAJUN, DAYS,
+	RuntimeCall, RuntimeEvent, RuntimeOrigin, TechnicalCommittee, BAJU, DAYS,
 };
 use frame_support::{
 	parameter_types,
@@ -128,7 +128,7 @@ parameter_types! {
 	pub const TwentyEightDays: BlockNumber = 28 * DAYS;
 	pub const ThirtyDays: BlockNumber = 30 * DAYS;
 	pub EnactmentPeriod: BlockNumber = 7 * DAYS;
-	pub const MinimumDeposit: Balance = 500 * BAJUN;
+	pub const MinimumDeposit: Balance = 500 * BAJU;
 }
 
 impl pallet_democracy::Config for Runtime {

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -174,9 +174,9 @@ pub struct WeightToFee;
 impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-		// in Rococo, extrinsic base weight (smallest non-zero weight) is mapped to 1 MILLI_BAJUN:
-		// in our template, we map to 1/10 of that, or 1/10 MILLI_BAJUN
-		let p = MILLI_BAJUN / 10;
+		// in Rococo, extrinsic base weight (smallest non-zero weight) is mapped to 1 MILLI_BAJU:
+		// in our template, we map to 1/10 of that, or 1/10 MILLI_BAJU
+		let p = MILLI_BAJU / 10;
 		let q = 100 * Balance::from(ExtrinsicBaseWeight::get().ref_time());
 		smallvec![WeightToFeeCoefficient {
 			degree: 1,
@@ -244,14 +244,14 @@ pub const HOURS: BlockNumber = MINUTES * 60;
 pub const DAYS: BlockNumber = HOURS * 24;
 
 // Unit = the base number of indivisible units for balances
-pub const BAJUN: Balance = 1_000_000_000_000;
-pub const MILLI_BAJUN: Balance = 1_000_000_000;
-pub const MICRO_BAJUN: Balance = 1_000_000;
-pub const NANO_BAJUN: Balance = 1_000;
-pub const PICO_BAJUN: Balance = 1;
+pub const BAJU: Balance = 1_000_000_000_000;
+pub const MILLI_BAJU: Balance = 1_000_000_000;
+pub const MICRO_BAJU: Balance = 1_000_000;
+pub const NANO_BAJU: Balance = 1_000;
+pub const PICO_BAJU: Balance = 1;
 
 /// The existential deposit. Set to 1/10 of the Connected Relay Chain.
-pub const EXISTENTIAL_DEPOSIT: Balance = MILLI_BAJUN;
+pub const EXISTENTIAL_DEPOSIT: Balance = MILLI_BAJU;
 
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.
@@ -479,7 +479,7 @@ impl pallet_balances::Config for Runtime {
 
 parameter_types! {
 	/// Relay Chain `TransactionByteFee` / 10
-	pub const TransactionByteFee: Balance = 10 * MICRO_BAJUN;
+	pub const TransactionByteFee: Balance = 10 * MICRO_BAJU;
 	pub const OperationalFeeMultiplier: u8 = 5;
 }
 
@@ -500,8 +500,8 @@ parameter_types! {
 	pub const ZeroPercent: Permill = Permill::from_percent(0);
 	pub const FivePercent: Permill = Permill::from_percent(5);
 	pub const FiftyPercent: Permill = Permill::from_percent(50);
-	pub const MinimumProposalBond: Balance = BAJUN;
-	pub const MaximumProposalBond: Balance = 500 * BAJUN;
+	pub const MinimumProposalBond: Balance = BAJU;
+	pub const MaximumProposalBond: Balance = 500 * BAJU;
 	pub const Fortnightly: BlockNumber = 14 * DAYS;
 	pub const Weekly: BlockNumber = 7 * DAYS;
 	pub const Daily: BlockNumber = DAYS;
@@ -543,7 +543,7 @@ impl pallet_treasury::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MinVestedTransfer: Balance = MILLI_BAJUN;
+	pub const MinVestedTransfer: Balance = MILLI_BAJU;
 }
 
 impl orml_vesting::Config for Runtime {
@@ -675,7 +675,7 @@ impl pallet_collator_selection::Config for Runtime {
 }
 
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
-	items as Balance * 20 * BAJUN + (bytes as Balance) * 1_000 * MICRO_BAJUN
+	items as Balance * 20 * BAJU + (bytes as Balance) * 1_000 * MICRO_BAJU
 }
 
 parameter_types! {
@@ -822,8 +822,8 @@ impl pallet_ajuna_awesome_avatars::Config for Runtime {
 }
 
 parameter_types! {
-	pub const CollectionDeposit: Balance = 100 * BAJUN;
-	pub const ItemDeposit: Balance = BAJUN / 10;
+	pub const CollectionDeposit: Balance = 100 * BAJU;
+	pub const ItemDeposit: Balance = BAJU / 10;
 	pub const StringLimit: u32 = 128;
 	pub const MetadataDepositBase: Balance = deposit(1, 129);
 	pub const AttributeDepositBase: Balance = deposit(1, 0);

--- a/runtime/bajun/src/xcm_config.rs
+++ b/runtime/bajun/src/xcm_config.rs
@@ -19,7 +19,7 @@
 use super::{
 	AccountId, AssetRegistry, Assets, Balance, Balances, MessageQueue, ParachainInfo,
 	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
-	TreasuryAccount, XcmpQueue, BAJUN,
+	TreasuryAccount, XcmpQueue, BAJU,
 };
 use crate::weights;
 use core::marker::PhantomData;
@@ -68,7 +68,7 @@ parameter_types! {
 	pub const MaxInstructions: u32 = 100;
 }
 
-/// Supported local Currencies. Keep this to BAJUN,
+/// Supported local Currencies. Keep this to BAJU,
 /// other assets will be handled through AssetRegistry pallet
 #[derive(
 	Encode,
@@ -95,9 +95,9 @@ impl Convert<Location, Option<CurrencyId>> for CurrencyIdConvert {
 		let self_para_id: u32 = ParachainInfo::parachain_id().into();
 
 		match location.unpack() {
-			// that's how xTokens with Karura, Bifrost, Moonriver refers to BAJUN
+			// that's how xTokens with Karura, Bifrost, Moonriver refers to BAJU
 			(1, [Parachain(id), BAJU_GENERAL_KEY]) if *id == self_para_id => Some(CurrencyId::BAJU),
-			// that's how the Asset Hub refers to BAJUN
+			// that's how the Asset Hub refers to BAJU
 			(1, [Parachain(id)]) if *id == self_para_id => Some(CurrencyId::BAJU),
 			// same for local location spec. we don't care if parents is 0 or 1
 			(0, [BAJU_GENERAL_KEY]) => Some(CurrencyId::BAJU),
@@ -141,7 +141,7 @@ pub type LocationToAccountId = (
 	HashedDescription<AccountId, DescribeFamily<DescribeAllTerminal>>,
 );
 
-/// Means for transacting BAJUN only.
+/// Means for transacting BAJU only.
 #[allow(deprecated)]
 pub type LocalNativeTransactor = CurrencyAdapter<
 	// Use this currency:
@@ -298,12 +298,12 @@ impl Contains<(Location, Vec<Asset>)> for OnlyTeleportNative {
 }
 
 pub type Traders = (
-	// for BAJUN
+	// for BAJU
 	FixedRateOfFungible<
 		NativePerSecond,
 		XcmFeesTo32ByteAccount<LocalNativeTransactor, AccountId, TreasuryAccount>,
 	>,
-	// for BAJUN for XCM from Karura, Bifrost, Moonriver
+	// for BAJU for XCM from Karura, Bifrost, Moonriver
 	FixedRateOfFungible<
 		NativeAliasPerSecond,
 		XcmFeesTo32ByteAccount<LocalNativeTransactor, AccountId, TreasuryAccount>,
@@ -317,9 +317,9 @@ pub type Traders = (
 
 parameter_types! {
 	pub const MaxAssetsIntoHolding: u32 = 64;
-	pub NativePerSecond: (AssetId, u128,u128) = (Location::new(0,Here).into(), BAJUN * 70, 0u128);
-	pub NativeAliasPerSecond: (AssetId, u128,u128) = (Location::new(0,[BAJU_GENERAL_KEY]).into(), BAJUN * 70, 0u128);
-	pub RelayNativePerSecond: (AssetId, u128,u128) = (Location::new(1,Here).into(), BAJUN * 70, 0u128);
+	pub NativePerSecond: (AssetId, u128,u128) = (Location::new(0,Here).into(), BAJU * 70, 0u128);
+	pub NativeAliasPerSecond: (AssetId, u128,u128) = (Location::new(0,[BAJU_GENERAL_KEY]).into(), BAJU * 70, 0u128);
+	pub RelayNativePerSecond: (AssetId, u128,u128) = (Location::new(1,Here).into(), BAJU * 70, 0u128);
 	// Weight for one XCM operation.
 	pub UnitWeightCost: Weight = Weight::from_parts(1_000_000u64, DEFAULT_PROOF_SIZE);
 	pub const BajunNative: AssetFilter = Wild(AllOf { fun: WildFungible, id: AssetId(Location::here()) });
@@ -440,7 +440,7 @@ parameter_types! {
 	pub const MaxAssetsForTransfer: usize = 2;
 }
 
-// What follows here are specialties only used for xToken reserve-transferring BAJUN to Karura,
+// What follows here are specialties only used for xToken reserve-transferring BAJU to Karura,
 // Bifrost and Moonriver
 
 // The min fee amount in fee asset is split into two parts:


### PR DESCRIPTION
We recently discovered that the variable name for our currency is wrong, it should be:

* Parachain name: Bajun Network
* Currency: BAJU

This is only a renaming and does not affect anything. We already put the correct reference to the currency for our XCM stuff (which is when we discovered that BAJUN was wrong)